### PR TITLE
Parse yes no question on reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /dist
+/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1ff-chat-ui",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "1ff-chat-ui",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "ISC",
       "dependencies": {
         "socket.io-client": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1ff-chat-ui",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "chatbot to communicate with taught ai",
   "main": "src/lib/chat-ui.js",
   "scripts": {

--- a/src/lib/chat-ui.js
+++ b/src/lib/chat-ui.js
@@ -118,7 +118,6 @@ const ChatUi = {
   loadUserHistory(history) {
     input.show(this);
     this.elements.messageIncrementor.appendChild(timeMarkup(history[0].time));
-    history.forEach((data) => this.appendHtml(data));
 
     this.historyTraverse(history);
 
@@ -145,7 +144,7 @@ const ChatUi = {
       time: new Date().toISOString(),
       role: roles.user,
     };
-    this.appendHtml(data, false);
+    this.appendHtml(data);
     this.onError();
   },
   shouldHideChat() {
@@ -249,7 +248,7 @@ const ChatUi = {
       time: new Date().toISOString(),
     };
     socketEmitChat(this);
-    this.appendHtml(data, false);
+    this.appendHtml(data);
     e.target.parentElement.remove();
   },
   addOptions() {
@@ -330,7 +329,7 @@ const ChatUi = {
    * @param {Object} data - The chat message data object.
    * @returns {void}
    */
-  appendHtml(data, isLastMessage) {
+  appendHtml(data, isLastMessage = false) {
     const { role, content } = data;
     const result = rolesHTML[role](content);
 
@@ -382,7 +381,7 @@ const ChatUi = {
         ...this.assistant.initialMessage,
       };
       this.elements.messageIncrementor.appendChild(timeMarkup(data.time));
-      this.appendHtml(data, false);
+      this.appendHtml(data);
 
       if (extractedString) {
         input.hide(this);
@@ -410,7 +409,7 @@ const ChatUi = {
     lastMessages.push(content);
     this.lastQuestionData.message = lastMessages.join('\n');
 
-    this.appendHtml(data, false);
+    this.appendHtml(data);
     this.elements.messageInput.value = '';
   },
   /**

--- a/src/lib/chat-widgets.js
+++ b/src/lib/chat-widgets.js
@@ -77,9 +77,10 @@ export const rolesHTML = {
     elementContent.className = 'js-assistant-message';
     element.classList.add('assistant');
     element.appendChild(elementContent);
-    const { updatedMessage } = extractStringWithBrackets(content);
+    const { extractedString, updatedMessage } = extractStringWithBrackets(content);
+
     elementContent.innerHTML = replaceLinksWithAnchors(replaceStringInCurlyBracketsWithStrong(updatedMessage));
-    return element;
+    return {extractedString, element};
   },
 };
 

--- a/src/lib/socket-services.js
+++ b/src/lib/socket-services.js
@@ -13,8 +13,10 @@ import { errorMessage, input, loadingDots, messages, resendButton } from './util
 export function onStreamStart() {
   window.debugMode && console.log('stream-start');
   loadingDots.hide();
-  this.elements.messageIncrementor.appendChild(rolesHTML['assistant'](''));
-}
+
+  const {element} = rolesHTML['assistant']('');
+  this.elements.messageIncrementor.appendChild(element);
+};
 
 /**
  * Handles the connect event.


### PR DESCRIPTION
This pr is bug fix for text of type `[yes|no]` which should result in two buttons on reload.
This buttons should appear on the last assistant message if the message includes buttons (no matter if it is initial message or another).
